### PR TITLE
fix: react lifecycle correction / change image in same instance when props change

### DIFF
--- a/src/components/ImageLoader.js
+++ b/src/components/ImageLoader.js
@@ -75,7 +75,7 @@ class ImageLoader extends React.PureComponent {
     // Set initial state
     this.state = {
       // Get all the image sources given as an array
-      imageSources: this.getAllImageSources(props),
+      imageSources: ImageLoader.getAllImageSources(props),
 
       // Keeping track of what we've done already
       // We keep the index of what we are currently trying to display
@@ -103,7 +103,7 @@ class ImageLoader extends React.PureComponent {
 
     if (sourceChanged || fallbackChanged) {
       // Get the imagesources into an array
-      const imageSources = this.getAllImageSources(nextProps);
+      const imageSources = ImageLoader.getAllImageSources(nextProps);
 
       return {
         // Set the new state variables
@@ -120,7 +120,7 @@ class ImageLoader extends React.PureComponent {
    * @param  {any}   props  The props to get the images from
    * @return {Array}        Array of image sources
    */
-  getAllImageSources = (props) => {
+  static getAllImageSources = (props) => {
     // Create a new array
     let imageSources = [];
 

--- a/src/components/ImageLoader.js
+++ b/src/components/ImageLoader.js
@@ -80,6 +80,10 @@ class ImageLoader extends React.PureComponent {
       // Keeping track of what we've done already
       // We keep the index of what we are currently trying to display
       currentImageIndex: 0,
+
+      // Stored for comparison with future props
+      source: props.source,
+      fallback: props.fallback
     };
   }
 
@@ -109,6 +113,8 @@ class ImageLoader extends React.PureComponent {
         // Set the new state variables
         imageSources,
         currentImageIndex: 0, // Reset the trying index
+        source: nextProps.source,
+        fallback: nextProps.fallback
       };
     }
 


### PR DESCRIPTION

Hi @mthahzan - here's the PR I mentioned I'd submit - Fixes #9 

Without this, I was sometimes seeing the same image fallback component not change images when I changed props. Both commits are necessary because 'this' is not valid in getDerivedStateFromProps and shows up as a crash once the state re-computation is actually happening correctly vs new props

For anyone else interested, also attaching a patch-package format patch based on this PR here, just strip the .txt extension off and put it in your patches dir and you are good to go

Cheers!

[react-native-image-fallback+1.0.0.patch.txt](https://github.com/mthahzan/react-native-image-fallback/files/6038931/react-native-image-fallback%2B1.0.0.patch.txt)
